### PR TITLE
Travis CI set up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ android:
   components:
     - build-tools-29.0.3
     - android-29
+  licenses:
+    # accept all licenses
+    - '.+'
 
 script:
   - cd plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: android
 dist: trusty
 
+android:
+  components:
+    - build-tools-29.0.3
+    - android-29
+
 script:
   - cd plugin
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ android:
     # accept all licenses
     - '.+'
 
+before_install:
+  - yes | sdkmanager "platforms;android-30"
+
 script:
   - cd plugin
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ dist: trusty
 
 script:
   - cd plugin
-  - gradlew test
+  - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,12 @@ android:
     - build-tools-30.0.0
     - android-30
 
+# accepting android build-tools-30.0.0's license
 before_install:
   - yes | sdkmanager "platforms;android-30"
 
 script:
   - cd plugin
+  # download dependency
   - wget -O ${GODOT_LIB_VERSION}/${GODOT_LIB_VERSION}.aar $GODOT_LIB_URL 
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: android
 dist: trusty
 
+env:
+  global:
+    - GODOT_LIB_VERSION=godot-lib.3.2.2.rc1.release
+    - GODOT_LIB_URL=https://downloads.tuxfamily.org/godotengine/3.2.2/rc1/godot-lib.3.2.2.rc1.release.aar
+
 android:
   components:
     - build-tools-30.0.0
     - android-30
-  licenses:
-    # accept all licenses
-    - '.+'
 
 before_install:
   - yes | sdkmanager "platforms;android-30"
 
 script:
   - cd plugin
-  - wget -O godot-lib.3.2.2.rc1.release/godot-lib.3.2.2.rc1.release.aar https://downloads.tuxfamily.org/godotengine/3.2.2/rc1/godot-lib.3.2.2.rc1.release.aar 
+  - wget -O ${GODOT_LIB_VERSION}/${GODOT_LIB_VERSION}.aar $GODOT_LIB_URL 
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ before_install:
 
 script:
   - cd plugin
+  - wget -O godot-lib.3.2.2.rc1.release/godot-lib.3.2.2.rc1.release.aar https://downloads.tuxfamily.org/godotengine/3.2.2/rc1/godot-lib.3.2.2.rc1.release.aar 
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 
 android:
   components:
-    - build-tools-29.0.3
-    - android-29
+    - build-tools-30.0.0
+    - android-30
   licenses:
     # accept all licenses
     - '.+'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: android
+dist: trusty
+
+script:
+  - cd plugin
+  - gradlew test

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -12,5 +12,5 @@
 /captures
 .externalNativeBuild
 .cxx
-/godot-lib.3.2.2.rc1.release/build
-/godot-lib.3.2.2.rc1.release/*.aar
+/godot-lib.*/build
+/godot-lib.*/*.aar

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -13,4 +13,4 @@
 .externalNativeBuild
 .cxx
 /godot-lib.3.2.2.rc1.release/build
-
+/godot-lib.3.2.2.rc1.release/*.aar

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -12,4 +12,5 @@
 /captures
 .externalNativeBuild
 .cxx
-/godot-lib.3.2.2.rc1.release
+/godot-lib.3.2.2.rc1.release/build
+

--- a/plugin/godot-lib.3.2.2.rc1.release/build.gradle
+++ b/plugin/godot-lib.3.2.2.rc1.release/build.gradle
@@ -1,0 +1,2 @@
+configurations.maybeCreate("default")
+artifacts.add("default", file('godot-lib.3.2.2.rc1.release.aar'))


### PR DESCRIPTION
Configured Travis CI for the plugin project.
Currently automatically builds and runs unit test using ./gradlew test for each pushed PR
Since Travis CI only reads configuration files at root directory, we need to append to this file (add more jobs) once we start working on the CI system of the front-facing API.