### PR TITLE
Added linter support for travis, reformatted files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,10 @@ before_install:
 script:
   - cd plugin
   # download dependency
-  - wget -O ${GODOT_LIB_VERSION}/${GODOT_LIB_VERSION}.aar $GODOT_LIB_URL 
+  - wget -O ${GODOT_LIB_VERSION}/${GODOT_LIB_VERSION}.aar $GODOT_LIB_URL
+  # Execute task verifyGoogleJavaFormat to verify all *.java files are correctly formatted
+  - ./gradlew verGJF
+  # execute test cases
   - ./gradlew test
+  # build aar library
+  - ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: android
 dist: trusty
-jdk:
-  - openjdk11
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - cd plugin
   # download dependency
   - wget -O ${GODOT_LIB_VERSION}/${GODOT_LIB_VERSION}.aar $GODOT_LIB_URL
-  # Execute task verifyGoogleJavaFormat to verify all *.java files are correctly formatted
+  # Execute task 'verifyGoogleJavaFormat' to verify all *.java files are correctly formatted
   - ./gradlew verGJF
   # execute test cases
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: android
 dist: trusty
+jdk:
+  - openjdk11
 
 env:
   global:

--- a/plugin/PlayAssetDelivery/src/androidTest/java/com/google/play/core/godot/assetpacks/ExampleInstrumentedTest.java
+++ b/plugin/PlayAssetDelivery/src/androidTest/java/com/google/play/core/godot/assetpacks/ExampleInstrumentedTest.java
@@ -1,30 +1,28 @@
 /*
-  	Copyright 2020 Google LLC
+ 	Copyright 2020 Google LLC
 
-  	Licensed under the Apache License, Version 2.0 (the "License");
-  	you may not use this file except in compliance with the License.
-  	You may obtain a copy of the License at
+ 	Licensed under the Apache License, Version 2.0 (the "License");
+ 	you may not use this file except in compliance with the License.
+ 	You may obtain a copy of the License at
 
-  		https://www.apache.org/licenses/LICENSE-2.0
+ 		https://www.apache.org/licenses/LICENSE-2.0
 
-  	Unless required by applicable law or agreed to in writing, software
-  	distributed under the License is distributed on an "AS IS" BASIS,
-  	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  	See the License for the specific language governing permissions and
-  	limitations under the License.
- */
+ 	Unless required by applicable law or agreed to in writing, software
+ 	distributed under the License is distributed on an "AS IS" BASIS,
+ 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ 	See the License for the specific language governing permissions and
+ 	limitations under the License.
+*/
 
 package com.google.play.core.godot.assetpacks;
 
+import static org.junit.Assert.*;
+
 import android.content.Context;
-
-import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
+import androidx.test.platform.app.InstrumentationRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.*;
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -33,10 +31,10 @@ import static org.junit.Assert.*;
  */
 @RunWith(AndroidJUnit4.class)
 public class ExampleInstrumentedTest {
-    @Test
-    public void useAppContext() {
-        // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        assertEquals("com.google.play.core.godot.assetpacks.test", appContext.getPackageName());
-    }
+  @Test
+  public void useAppContext() {
+    // Context of the app under test.
+    Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    assertEquals("com.google.play.core.godot.assetpacks.test", appContext.getPackageName());
+  }
 }

--- a/plugin/PlayAssetDelivery/src/main/java/com/google/play/core/godot/assetpacks/PlayAssetDelivery.java
+++ b/plugin/PlayAssetDelivery/src/main/java/com/google/play/core/godot/assetpacks/PlayAssetDelivery.java
@@ -17,15 +17,13 @@
 package com.google.play.core.godot.assetpacks;
 
 import androidx.annotation.NonNull;
-
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.godotengine.godot.Godot;
 import org.godotengine.godot.plugin.GodotPlugin;
 import org.godotengine.godot.plugin.SignalInfo;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.HashSet;
 
 /**
  * This class is served as a middleware, to expose the Play Core Java library to the Godot runtime,

--- a/plugin/PlayAssetDelivery/src/test/java/com/google/play/core/godot/assetpacks/PlayAssetDeliveryTest.java
+++ b/plugin/PlayAssetDelivery/src/test/java/com/google/play/core/godot/assetpacks/PlayAssetDeliveryTest.java
@@ -18,17 +18,14 @@ package com.google.play.core.godot.assetpacks;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.godotengine.godot.Godot;
-import org.godotengine.godot.plugin.SignalInfo;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import java.util.List;
 import java.util.Set;
+import org.godotengine.godot.Godot;
+import org.godotengine.godot.plugin.SignalInfo;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PlayAssetDeliveryTest {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.sherter.google-java-format' version '0.9'
+    id 'com.github.sherter.google-java-format' version '0.8'
 }
 
 allprojects {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -12,6 +12,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.github.sherter.google-java-format' version '0.9'
+}
+
 allprojects {
     repositories {
         google()

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.sherter.google-java-format' version '0.8'
+    id 'com.github.sherter.google-java-format' version '0.9'
 }
 
 allprojects {


### PR DESCRIPTION
Added a gradle based Java linter via [google-java-format-gradle-plugin](https://github.com/sherter/google-java-format-gradle-plugin) (under MIT license).
Updated travis configuration file, so that whenever we spin-up a travis build we would run the linter to check if code is formatted properly.