### PR TITLE
Implemented PlayAssetPackRequestTracker class

### DIFF
--- a/api/project.godot
+++ b/api/project.godot
@@ -25,6 +25,11 @@ _global_script_classes=[ {
 "path": "res://src/model/play_asset_pack_location.gd"
 }, {
 "base": "Object",
+"class": "PlayAssetPackRequest",
+"language": "GDScript",
+"path": "res://src/model/play_asset_pack_request.gd"
+}, {
+"base": "Object",
 "class": "PlayAssetPackRequestTracker",
 "language": "GDScript",
 "path": "res://src/play_asset_pack_request_tracker.gd"
@@ -43,6 +48,7 @@ _global_script_class_icons={
 "FakeAndroidPlugin": "",
 "PlayAssetLocation": "",
 "PlayAssetPackLocation": "",
+"PlayAssetPackRequest": "",
 "PlayAssetPackRequestTracker": "",
 "PlayAssetPackState": "",
 "PlayAssetPackStates": ""

--- a/api/project.godot
+++ b/api/project.godot
@@ -25,6 +25,11 @@ _global_script_classes=[ {
 "path": "res://src/model/play_asset_pack_location.gd"
 }, {
 "base": "Object",
+"class": "PlayAssetPackRequestTracker",
+"language": "GDScript",
+"path": "res://src/play_asset_pack_request_tracker.gd"
+}, {
+"base": "Object",
 "class": "PlayAssetPackState",
 "language": "GDScript",
 "path": "res://src/model/play_asset_pack_state.gd"
@@ -38,6 +43,7 @@ _global_script_class_icons={
 "FakeAndroidPlugin": "",
 "PlayAssetLocation": "",
 "PlayAssetPackLocation": "",
+"PlayAssetPackRequestTracker": "",
 "PlayAssetPackState": "",
 "PlayAssetPackStates": ""
 }

--- a/api/src/model/play_asset_pack_request.gd
+++ b/api/src/model/play_asset_pack_request.gd
@@ -1,0 +1,27 @@
+# ##############################################################################
+#
+#	Copyright 2020 Google LLC
+#
+#	Licensed under the Apache License, Version 2.0 (the "License");
+#	you may not use this file except in compliance with the License.
+#	You may obtain a copy of the License at
+#
+#		https://www.apache.org/licenses/LICENSE-2.0
+#
+#	Unless required by applicable law or agreed to in writing, software
+#	distributed under the License is distributed on an "AS IS" BASIS,
+#	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#	See the License for the specific language governing permissions and
+#	limitations under the License.
+#
+# ##############################################################################
+#
+# Base class used for handling async requests. Able to receive asynchronous 
+# signals emitted from PlayAssetDelivery Android Plugin.
+#
+# ##############################################################################
+class_name PlayAssetPackRequest
+extends Object
+
+func _init():
+	pass

--- a/api/src/play_asset_pack_manager.gd
+++ b/api/src/play_asset_pack_manager.gd
@@ -69,6 +69,7 @@ func _ready():
 
 func _initialize():
 	_plugin_singleton = _initialize_plugin()
+	_request_tracker = PlayAssetPackRequestTracker.new()
 
 # -----------------------------------------------------------------------------
 # Returns the PlayAssetDelivery Android Plugin singleton, null if this plugin

--- a/api/src/play_asset_pack_manager.gd
+++ b/api/src/play_asset_pack_manager.gd
@@ -24,6 +24,7 @@
 extends Node
 
 var _plugin_singleton : Object
+var _request_tracker : PlayAssetPackRequestTracker
 
 # -----------------------------------------------------------------------------
 # Enums

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -33,6 +33,7 @@ var _signal_id_counter : int
 var _signal_id_to_request_map : Dictionary
 
 func _init():
+	# On first request's registration, _signal_id_counter should be incremented to _SIGNAL_ID_MIN
 	_signal_id_counter = _SIGNAL_ID_MIN - 1
 	_signal_id_to_request_map = Dictionary()
 
@@ -52,7 +53,7 @@ func _increment_signal_id() -> void:
 		_signal_id_counter = _SIGNAL_ID_MIN - 1
 	_signal_id_counter += 1
 
-# registers the request object and returned the signal_id assigned
+# registers the request object and returns the signal_id assigned
 func register_request(request : PlayAssetPackRequest) -> int:
 	_increment_to_next_available_signal_id()
 	_signal_id_to_request_map[_signal_id_counter] = request
@@ -63,7 +64,7 @@ func lookup_request(signal_id : int) -> PlayAssetPackRequest:
 		return _signal_id_to_request_map[signal_id]
 	return null
 
-func remove_request(signal_id : int) -> void:
+func unregister_request(signal_id : int) -> void:
 	if signal_id in _signal_id_to_request_map:
 		_signal_id_to_request_map.erase(signal_id)
 

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -48,7 +48,8 @@ func _increment_to_next_available_signal_id():
 		_increment_signal_id()
 
 func _increment_signal_id() -> void:
-	# increment _signal_id_counter while avoid integer overflow by wrapping around to _SIGNAL_ID_MIN
+	# increment _signal_id_counter while avoid integer overflow by wrapping around to 
+	# _SIGNAL_ID_MIN
 	if _signal_id_counter == _SIGNAL_ID_MAX:
 		_signal_id_counter = _SIGNAL_ID_MIN - 1
 	_signal_id_counter += 1

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -54,6 +54,7 @@ func register_request(request : PlayAssetPackRequest) -> int:
 func lookup_request(signal_id : int) -> PlayAssetPackRequest:
 	_request_tracker_mutex.lock()
 	if signal_id in _signal_id_to_request_map:
+		_request_tracker_mutex.unlock()
 		return _signal_id_to_request_map[signal_id]
 	_request_tracker_mutex.unlock()
 	return null

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -20,7 +20,9 @@
 # keeps a mapping of signal_id to Request objects. This signal_id is used as an
 # identifier and passed to the Android plugin. Eventually the Android plugin will
 # emit signals along with this signal_id. In this way we can know which signal 
-# emitted from the plugin corresponds to which Request object
+# emitted from the plugin corresponds to which Request object. Since multiple
+# threads can read and write to _signal_id_to_request_map and _signal_id_counter,
+# we need to lock all the critical sections.
 #
 # ##############################################################################
 class_name PlayAssetPackRequestTracker
@@ -42,8 +44,6 @@ func get_current_signal_id() -> int:
 
 # registers the request object and returns the signal_id assigned
 func register_request(request : PlayAssetPackRequest) -> int:
-	# since we read _signal_id_counter at start and increment at end of this function,
-	# we need to make it a critical section
 	_request_tracker_mutex.lock()
 	var return_signal_id = _signal_id_counter
 	_signal_id_to_request_map[_signal_id_counter] = request

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -52,13 +52,12 @@ func register_request(request : PlayAssetPackRequest) -> int:
 	return return_signal_id
 
 func lookup_request(signal_id : int) -> PlayAssetPackRequest:
+	var return_request = null
 	_request_tracker_mutex.lock()
 	if signal_id in _signal_id_to_request_map:
-		var return_request = _signal_id_to_request_map[signal_id]
-		_request_tracker_mutex.unlock()
-		return return_request
+		return_request = _signal_id_to_request_map[signal_id]
 	_request_tracker_mutex.unlock()
-	return null
+	return return_request
 
 func unregister_request(signal_id : int) -> void:
 	_request_tracker_mutex.lock()

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -26,23 +26,37 @@
 class_name PlayAssetPackRequestTracker
 extends Object
 
+const _SIGNAL_ID_MAX = 9223372036854775807
+const _SIGNAL_ID_MIN = 0
+
 var _signal_id_counter : int
 var _signal_id_to_request_map : Dictionary
 
 func _init():
-	_signal_id_counter = 0
+	_signal_id_counter = _SIGNAL_ID_MIN
 	_signal_id_to_request_map = Dictionary()
 
 func get_current_signal_id() -> int:
 	return _signal_id_counter
 
-func increment_signal_id() -> void:
+# increment _signal_id_counter to the next available value not registered in 
+# _signal_id_to_request_map
+func _increment_to_next_available_signal_id():
+	_increment_signal_id()
+	while _signal_id_counter in _signal_id_to_request_map:
+		_increment_signal_id()
+
+# increment _signal_id_counter while avoid integer overflow by wrapping around to _SIGNAL_ID_MIN
+func _increment_signal_id() -> void:
+	if _signal_id_counter == _SIGNAL_ID_MAX:
+		_signal_id_counter = _SIGNAL_ID_MIN - 1
 	_signal_id_counter += 1
 
+# registers the request object and returned the signal_id assigned
 func register_request(request : PlayAssetPackRequest) -> int:
 	var return_signal_id = _signal_id_counter
 	_signal_id_to_request_map[return_signal_id] = request
-	increment_signal_id()
+	_increment_to_next_available_signal_id()
 	return return_signal_id
 
 func lookup_request(signal_id : int) -> PlayAssetPackRequest:

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -33,7 +33,7 @@ var _signal_id_to_request_map : Dictionary
 
 func _init():
 	# On first request's registration, _signal_id_counter should be incremented to _SIGNAL_ID_MIN
-	_signal_id_counter = _SIGNAL_ID_MIN - 1
+	_signal_id_counter = _SIGNAL_ID_MIN
 	_signal_id_to_request_map = Dictionary()
 
 func get_current_signal_id() -> int:
@@ -44,9 +44,10 @@ func _increment_signal_id() -> void:
 
 # registers the request object and returns the signal_id assigned
 func register_request(request : PlayAssetPackRequest) -> int:
-	_increment_signal_id()
+	var return_signal_id = _signal_id_counter
 	_signal_id_to_request_map[_signal_id_counter] = request
-	return _signal_id_counter
+	_increment_signal_id()
+	return return_signal_id
 
 func lookup_request(signal_id : int) -> PlayAssetPackRequest:
 	if signal_id in _signal_id_to_request_map:

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -40,9 +40,6 @@ func _init():
 func get_current_signal_id() -> int:
 	return _signal_id_counter
 
-func _increment_signal_id() -> void:
-	_signal_id_counter += 1
-
 # registers the request object and returns the signal_id assigned
 func register_request(request : PlayAssetPackRequest) -> int:
 	# since we read _signal_id_counter at start and increment at end of this function,
@@ -50,7 +47,7 @@ func register_request(request : PlayAssetPackRequest) -> int:
 	_register_request_mutex.lock()
 	var return_signal_id = _signal_id_counter
 	_signal_id_to_request_map[_signal_id_counter] = request
-	_increment_signal_id()
+	_signal_id_counter += 1
 	_register_request_mutex.unlock()
 	return return_signal_id
 

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -33,12 +33,24 @@ func _init():
 	_signal_id_counter = 0
 	_signal_id_to_request_map = Dictionary()
 
-func get_current_signal_id():
+func get_current_signal_id() -> int:
 	return _signal_id_counter
 
-func increment_signal_id():
+func increment_signal_id() -> void:
 	_signal_id_counter += 1
 
 func register_request(request : PlayAssetPackRequest) -> int:
 	var return_signal_id = _signal_id_counter
-	
+	_signal_id_to_request_map[return_signal_id] = request
+	increment_signal_id()
+	return return_signal_id
+
+func lookup_request(signal_id : int) -> PlayAssetPackRequest:
+	if signal_id in _signal_id_to_request_map:
+		return _signal_id_to_request_map[signal_id]
+	return null
+
+func remove_request(signal_id : int) -> void:
+	if signal_id in _signal_id_to_request_map:
+		_signal_id_to_request_map.erase(signal_id)
+

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -33,7 +33,7 @@ var _signal_id_counter : int
 var _signal_id_to_request_map : Dictionary
 
 func _init():
-	_signal_id_counter = _SIGNAL_ID_MIN
+	_signal_id_counter = _SIGNAL_ID_MIN - 1
 	_signal_id_to_request_map = Dictionary()
 
 func get_current_signal_id() -> int:
@@ -54,10 +54,9 @@ func _increment_signal_id() -> void:
 
 # registers the request object and returned the signal_id assigned
 func register_request(request : PlayAssetPackRequest) -> int:
-	var return_signal_id = _signal_id_counter
-	_signal_id_to_request_map[return_signal_id] = request
 	_increment_to_next_available_signal_id()
-	return return_signal_id
+	_signal_id_to_request_map[_signal_id_counter] = request
+	return _signal_id_counter
 
 func lookup_request(signal_id : int) -> PlayAssetPackRequest:
 	if signal_id in _signal_id_to_request_map:

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -40,15 +40,15 @@ func _init():
 func get_current_signal_id() -> int:
 	return _signal_id_counter
 
-# increment _signal_id_counter to the next available value not registered in 
-# _signal_id_to_request_map
 func _increment_to_next_available_signal_id():
+	# increment _signal_id_counter to the next available value not registered in 
+	# _signal_id_to_request_map
 	_increment_signal_id()
 	while _signal_id_counter in _signal_id_to_request_map:
 		_increment_signal_id()
 
-# increment _signal_id_counter while avoid integer overflow by wrapping around to _SIGNAL_ID_MIN
 func _increment_signal_id() -> void:
+	# increment _signal_id_counter while avoid integer overflow by wrapping around to _SIGNAL_ID_MIN
 	if _signal_id_counter == _SIGNAL_ID_MAX:
 		_signal_id_counter = _SIGNAL_ID_MIN - 1
 	_signal_id_counter += 1

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -26,7 +26,6 @@
 class_name PlayAssetPackRequestTracker
 extends Object
 
-const _SIGNAL_ID_MAX = 9223372036854775807
 const _SIGNAL_ID_MIN = 0
 
 var _signal_id_counter : int
@@ -40,23 +39,12 @@ func _init():
 func get_current_signal_id() -> int:
 	return _signal_id_counter
 
-func _increment_to_next_available_signal_id():
-	# increment _signal_id_counter to the next available value not registered in 
-	# _signal_id_to_request_map
-	_increment_signal_id()
-	while _signal_id_counter in _signal_id_to_request_map:
-		_increment_signal_id()
-
 func _increment_signal_id() -> void:
-	# increment _signal_id_counter while avoid integer overflow by wrapping around to 
-	# _SIGNAL_ID_MIN
-	if _signal_id_counter == _SIGNAL_ID_MAX:
-		_signal_id_counter = _SIGNAL_ID_MIN - 1
 	_signal_id_counter += 1
 
 # registers the request object and returns the signal_id assigned
 func register_request(request : PlayAssetPackRequest) -> int:
-	_increment_to_next_available_signal_id()
+	_increment_signal_id()
 	_signal_id_to_request_map[_signal_id_counter] = request
 	return _signal_id_counter
 

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -32,7 +32,6 @@ var _signal_id_counter : int
 var _signal_id_to_request_map : Dictionary
 
 func _init():
-	# On first request's registration, _signal_id_counter should be incremented to _SIGNAL_ID_MIN
 	_signal_id_counter = _SIGNAL_ID_MIN
 	_signal_id_to_request_map = Dictionary()
 

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -22,7 +22,7 @@
 # emit signals along with this signal_id. In this way we can know which signal 
 # emitted from the plugin corresponds to which Request object. Since multiple
 # threads can read and write to _signal_id_to_request_map and _signal_id_counter,
-# we need to lock all the critical sections.
+# we need to handle all the critical sections.
 #
 # ##############################################################################
 class_name PlayAssetPackRequestTracker

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -1,0 +1,31 @@
+# ##############################################################################
+#
+#	Copyright 2020 Google LLC
+#
+#	Licensed under the Apache License, Version 2.0 (the "License");
+#	you may not use this file except in compliance with the License.
+#	You may obtain a copy of the License at
+#
+#		https://www.apache.org/licenses/LICENSE-2.0
+#
+#	Unless required by applicable law or agreed to in writing, software
+#	distributed under the License is distributed on an "AS IS" BASIS,
+#	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#	See the License for the specific language governing permissions and
+#	limitations under the License.
+#
+# ##############################################################################
+#
+# The PlayAssetPackRequestTracker class generates unique signal_id integers and
+# keeps a mapping of signal_id to Request objects. This signal_id is used as an
+# identifier and passed to the Android plugin, so that we can know which signal
+# emitted from the plugin corresponds to which Request object
+#
+# ##############################################################################
+class_name PlayAssetPackRequestTracker
+extends Object
+
+var signal_id_counter : int
+
+func _init():
+	signal_id_counter = 0

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -54,8 +54,9 @@ func register_request(request : PlayAssetPackRequest) -> int:
 func lookup_request(signal_id : int) -> PlayAssetPackRequest:
 	_request_tracker_mutex.lock()
 	if signal_id in _signal_id_to_request_map:
+		var return_request = _signal_id_to_request_map[signal_id]
 		_request_tracker_mutex.unlock()
-		return _signal_id_to_request_map[signal_id]
+		return return_request
 	_request_tracker_mutex.unlock()
 	return null
 

--- a/api/src/play_asset_pack_request_tracker.gd
+++ b/api/src/play_asset_pack_request_tracker.gd
@@ -18,14 +18,27 @@
 #
 # The PlayAssetPackRequestTracker class generates unique signal_id integers and
 # keeps a mapping of signal_id to Request objects. This signal_id is used as an
-# identifier and passed to the Android plugin, so that we can know which signal
+# identifier and passed to the Android plugin. Eventually the Android plugin will
+# emit signals along with this signal_id. In this way we can know which signal 
 # emitted from the plugin corresponds to which Request object
 #
 # ##############################################################################
 class_name PlayAssetPackRequestTracker
 extends Object
 
-var signal_id_counter : int
+var _signal_id_counter : int
+var _signal_id_to_request_map : Dictionary
 
 func _init():
-	signal_id_counter = 0
+	_signal_id_counter = 0
+	_signal_id_to_request_map = Dictionary()
+
+func get_current_signal_id():
+	return _signal_id_counter
+
+func increment_signal_id():
+	_signal_id_counter += 1
+
+func register_request(request : PlayAssetPackRequest) -> int:
+	var return_signal_id = _signal_id_counter
+	

--- a/api/test/test_play_asset_pack_request_tracker.gd
+++ b/api/test/test_play_asset_pack_request_tracker.gd
@@ -17,7 +17,6 @@
 # ##############################################################################
 
 extends "res://test/test_helper/base_test_class.gd"
-signal start_concurrency_signal
 
 func test_register_request_single_request():
 	var test_request_tracker = PlayAssetPackRequestTracker.new()

--- a/api/test/test_play_asset_pack_request_tracker.gd
+++ b/api/test/test_play_asset_pack_request_tracker.gd
@@ -1,0 +1,82 @@
+# ##############################################################################
+#
+#	Copyright 2020 Google LLC
+#
+#	Licensed under the Apache License, Version 2.0 (the "License");
+#	you may not use this file except in compliance with the License.
+#	You may obtain a copy of the License at
+#
+#		https://www.apache.org/licenses/LICENSE-2.0
+#
+#	Unless required by applicable law or agreed to in writing, software
+#	distributed under the License is distributed on an "AS IS" BASIS,
+#	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#	See the License for the specific language governing permissions and
+#	limitations under the License.
+#
+# ##############################################################################
+
+extends "res://test/test_helper/base_test_class.gd"
+
+func test_register_request_single_request():
+	var test_request_tracker = PlayAssetPackRequestTracker.new()
+	var test_request_object = PlayAssetPackRequest.new()
+	
+	var test_signal_id = test_request_tracker.register_request(test_request_object)
+	
+	assert_eq(test_signal_id, PlayAssetPackRequestTracker._SIGNAL_ID_MIN)
+	assert_eq(test_request_tracker.lookup_request(test_signal_id), test_request_object)
+	
+func test_register_request_multiple_requests():
+	var test_request_tracker = PlayAssetPackRequestTracker.new()
+
+	var test_request_object1 = PlayAssetPackRequest.new()
+	var test_request_object2 = PlayAssetPackRequest.new()
+	var test_request_object3 = PlayAssetPackRequest.new()
+	var test_request_object4 = PlayAssetPackRequest.new()
+	var test_request_object5 = PlayAssetPackRequest.new()
+
+	var test_signal_id1 = test_request_tracker.register_request(test_request_object1)
+	var test_signal_id2 = test_request_tracker.register_request(test_request_object2)
+	var test_signal_id3 = test_request_tracker.register_request(test_request_object3)
+	var test_signal_id4 = test_request_tracker.register_request(test_request_object4)
+	var test_signal_id5 = test_request_tracker.register_request(test_request_object5)
+	
+	assert_eq(test_signal_id1, PlayAssetPackRequestTracker._SIGNAL_ID_MIN)
+	assert_eq(test_signal_id2, PlayAssetPackRequestTracker._SIGNAL_ID_MIN + 1)
+	assert_eq(test_signal_id3, PlayAssetPackRequestTracker._SIGNAL_ID_MIN + 2)
+	assert_eq(test_signal_id4, PlayAssetPackRequestTracker._SIGNAL_ID_MIN + 3)
+	assert_eq(test_signal_id5, PlayAssetPackRequestTracker._SIGNAL_ID_MIN + 4)
+
+	assert_eq(test_request_tracker.lookup_request(test_signal_id1), test_request_object1)
+	assert_eq(test_request_tracker.lookup_request(test_signal_id2), test_request_object2)
+	assert_eq(test_request_tracker.lookup_request(test_signal_id3), test_request_object3)
+	assert_eq(test_request_tracker.lookup_request(test_signal_id4), test_request_object4)
+	assert_eq(test_request_tracker.lookup_request(test_signal_id5), test_request_object5)
+
+func test_lookup_request_nonexistent_signal_id():
+	var test_request_tracker = PlayAssetPackRequestTracker.new()
+	var test_signal_id = 42
+	assert_eq(test_request_tracker.lookup_request(test_signal_id), null)
+
+func test_remove_request_valid():
+	var test_request_tracker = PlayAssetPackRequestTracker.new()
+	var test_request_object = PlayAssetPackRequest.new()
+	
+	var test_signal_id = test_request_tracker.register_request(test_request_object)
+	test_request_tracker.remove_request(test_signal_id)
+	
+	assert_true(not test_signal_id in test_request_tracker._signal_id_to_request_map)
+	assert_eq(test_request_tracker.lookup_request(test_signal_id), null)
+
+func test_signal_id_overflow():
+	var test_request_tracker = PlayAssetPackRequestTracker.new()
+	var test_request_object = PlayAssetPackRequest.new()
+	
+	test_request_tracker._signal_id_counter = PlayAssetPackRequestTracker._SIGNAL_ID_MAX
+
+	var test_signal_id = test_request_tracker.register_request(test_request_object)
+	
+	assert_eq(test_signal_id, PlayAssetPackRequestTracker._SIGNAL_ID_MIN)
+	assert_eq(test_request_tracker.lookup_request(test_signal_id), test_request_object)
+	

--- a/api/test/test_play_asset_pack_request_tracker.gd
+++ b/api/test/test_play_asset_pack_request_tracker.gd
@@ -72,39 +72,3 @@ func test_remove_request_valid():
 	
 	assert_true(not test_signal_id in test_request_tracker._signal_id_to_request_map)
 	assert_eq(test_request_tracker.lookup_request(test_signal_id), null)
-
-func test_signal_id_handle_overflow():
-	var test_request_tracker = PlayAssetPackRequestTracker.new()
-	var test_request_object = PlayAssetPackRequest.new()
-	
-	# manual set _signal_id_counter to _SIGNAL_ID_MAX
-	test_request_tracker._signal_id_counter = PlayAssetPackRequestTracker._SIGNAL_ID_MAX
-
-	var test_signal_id = test_request_tracker.register_request(test_request_object)
-	
-	# updated _signal_id_counter should be _SIGNAL_ID_MIN
-	assert_eq(test_request_tracker.get_current_signal_id(), PlayAssetPackRequestTracker._SIGNAL_ID_MIN)
-	assert_eq(test_request_tracker.lookup_request(test_signal_id), test_request_object)
-
-func test_signal_id_skip_existing_ids():
-	var test_request_tracker = PlayAssetPackRequestTracker.new()
-	var test_request_object = PlayAssetPackRequest.new()
-	
-	var existing_request_object1 = PlayAssetPackRequest.new()
-	var existing_request_object2 = PlayAssetPackRequest.new()
-	
-	test_request_tracker._signal_id_to_request_map[0] = existing_request_object1
-	test_request_tracker._signal_id_to_request_map[1] = existing_request_object2
-	
-	# the current _signal_id_counter is still _SIGNAL_ID_MIN - 1, but the next available id in mp 
-	# will be 2
-	assert_eq(test_request_tracker._signal_id_counter, PlayAssetPackRequestTracker._SIGNAL_ID_MIN - 1)
-	
-	var test_signal_id = test_request_tracker.register_request(test_request_object)
-	
-	assert_eq(test_signal_id, PlayAssetPackRequestTracker._SIGNAL_ID_MIN + 2)
-	assert_eq(test_request_tracker.lookup_request(test_signal_id), test_request_object)
-	# check if existing request objects are not overwritten
-	assert_eq(test_request_tracker.lookup_request(PlayAssetPackRequestTracker._SIGNAL_ID_MIN), existing_request_object1)
-	assert_eq(test_request_tracker.lookup_request(PlayAssetPackRequestTracker._SIGNAL_ID_MIN + 1), existing_request_object2)
-

--- a/api/test/test_play_asset_pack_request_tracker.gd
+++ b/api/test/test_play_asset_pack_request_tracker.gd
@@ -68,7 +68,7 @@ func test_remove_request_valid():
 	var test_request_object = PlayAssetPackRequest.new()
 	
 	var test_signal_id = test_request_tracker.register_request(test_request_object)
-	test_request_tracker.remove_request(test_signal_id)
+	test_request_tracker.unregister_request(test_signal_id)
 	
 	assert_true(not test_signal_id in test_request_tracker._signal_id_to_request_map)
 	assert_eq(test_request_tracker.lookup_request(test_signal_id), null)

--- a/api/test/test_play_asset_pack_request_tracker.gd
+++ b/api/test/test_play_asset_pack_request_tracker.gd
@@ -74,7 +74,7 @@ func test_remove_request_valid():
 	assert_eq(test_request_tracker.lookup_request(test_signal_id), null)
 
 func test_register_request_concurrency():
-	# Use Godot's multithreading API to register serveral requests at once.
+	# Use Godot's multithreading API to register several requests at once.
 	# Test if RequestTracker is thread-safe
 	var test_request_tracker = PlayAssetPackRequestTracker.new()
 

--- a/plugin/PlayAssetDelivery/src/main/java/com/google/play/core/godot/assetpacks/PlayAssetDelivery.java
+++ b/plugin/PlayAssetDelivery/src/main/java/com/google/play/core/godot/assetpacks/PlayAssetDelivery.java
@@ -274,9 +274,9 @@ public class PlayAssetDelivery extends GodotPlugin {
   }
 
   /**
-   * Calls removePack(String packName) method in the Play Core Library. Deletes the
-   * specified asset pack from the internal storage of the app. Emits removePackSuccess and
-   * removePackError signals when the underlying task succeeds/fails.
+   * Calls removePack(String packName) method in the Play Core Library. Deletes the specified asset
+   * pack from the internal storage of the app. Emits removePackSuccess and removePackError signals
+   * when the underlying task succeeds/fails.
    *
    * @param packName name of the asset pack to be removed
    * @param signalID identifier used to track mapping of signals to Tasks

--- a/plugin/PlayAssetDelivery/src/main/java/com/google/play/core/godot/assetpacks/PlayAssetDelivery.java
+++ b/plugin/PlayAssetDelivery/src/main/java/com/google/play/core/godot/assetpacks/PlayAssetDelivery.java
@@ -199,7 +199,7 @@ public class PlayAssetDelivery extends GodotPlugin {
    * @param packNamesArray String Array for all the packs to be fetched
    * @param signalID identifier used to track mapping of signals to Tasks
    */
-  public void fetch(String[] packNamesArray, int signalID) {
+  public void fetch(String[] packNamesArray, long signalID) {
     List<String> packNames = Arrays.asList(packNamesArray);
 
     OnSuccessListener<AssetPackStates> fetchSuccessListener =
@@ -252,7 +252,7 @@ public class PlayAssetDelivery extends GodotPlugin {
    * @param packNamesArray String Array for all the packs to request states
    * @param signalID identifier used to track mapping of signals to Tasks
    */
-  public void getPackStates(String[] packNamesArray, int signalID) {
+  public void getPackStates(String[] packNamesArray, long signalID) {
     List<String> packNames = Arrays.asList(packNamesArray);
 
     OnSuccessListener<AssetPackStates> getPackStatesSuccessListener =
@@ -274,14 +274,14 @@ public class PlayAssetDelivery extends GodotPlugin {
   }
 
   /**
-   * Calls removePack(String packName, int signalID) method in the Play Core Library. Deletes the
+   * Calls removePack(String packName) method in the Play Core Library. Deletes the
    * specified asset pack from the internal storage of the app. Emits removePackSuccess and
    * removePackError signals when the underlying task succeeds/fails.
    *
    * @param packName name of the asset pack to be removed
    * @param signalID identifier used to track mapping of signals to Tasks
    */
-  public void removePack(String packName, int signalID) {
+  public void removePack(String packName, long signalID) {
     OnSuccessListener<Void> removePackOnSuccessListener =
         result -> emitSignalWrapper(REMOVE_PACK_SUCCESS, signalID);
     OnFailureListener removePackOnFailureListener =
@@ -305,7 +305,7 @@ public class PlayAssetDelivery extends GodotPlugin {
    *
    * @param signalID identifier used to track mapping of signals to Tasks
    */
-  public void showCellularDataConfirmation(int signalID) {
+  public void showCellularDataConfirmation(long signalID) {
     OnSuccessListener<Integer> showCellularDataConfirmationSuccessListener =
         result -> emitSignalWrapper(SHOW_CELLULAR_DATA_CONFIRMATION_SUCCESS, result, signalID);
     OnFailureListener showCellularDataConfirmationFailureListener =


### PR DESCRIPTION
PlayAssetPackRequestTracker can generate new SignalIDs and keep the mapping of SignalID to Request Objects, allowing us to keep track of which signal emitted by the Android Plugin corresponds to which Request Object. 
Below is a sequence diagram describing the context for PlayAssetPackRequestTracker. 
<img width="830" alt="Screen Shot 2020-07-17 at 5 51 49 PM" src="https://user-images.githubusercontent.com/14120761/87836615-43e44f00-c856-11ea-8969-c16f745f6195.png">
