### PR TITLE
Api bug fix 2

### DIFF
--- a/api/src/play_asset_pack_manager.gd
+++ b/api/src/play_asset_pack_manager.gd
@@ -149,6 +149,8 @@ func _route_asset_pack_state_updated(result : Dictionary):
 	if _asset_pack_to_request_map.has(pack_name):
 		var request = _asset_pack_to_request_map[pack_name]
 		request.call_deferred("_on_state_updated", result)
+		if updated_state.get_status() in _PACK_TERMINAL_STATES:
+			_asset_pack_to_request_map.erase(pack_name)
 	
 	call_deferred("emit_signal", "state_updated", pack_name, updated_state)	
 	
@@ -187,6 +189,8 @@ func _forward_fetch_error(error : Dictionary, signal_id : int):
 	previous_state[PlayAssetPackState._STATUS_KEY] = AssetPackStatus.FAILED
 	previous_state[PlayAssetPackState._ERROR_CODE_KEY] = error[PlayAssetPackException._ERROR_CODE_KEY]
 	_forward_high_level_state_updated_signal(pack_name, previous_state)
+	
+	_asset_pack_to_request_map.erase(pack_name)
 
 func _forward_get_pack_states_success(result : Dictionary, signal_id : int):
 	var target_request : PlayAssetPackStateRequest = _request_tracker.lookup_request(signal_id)
@@ -301,7 +305,11 @@ func cancel_asset_pack_request(pack_name : String) -> bool:
 	var updated_asset_pack_state : PlayAssetPackState = updated_asset_pack_states.get_pack_states()[pack_name]
 	var updated_asset_pack_status = updated_asset_pack_state.get_status()
 	
-	return updated_asset_pack_status == AssetPackStatus.CANCELED
+	var cancellation_success = AssetPackStatus.CANCELED == AssetPackStatus.CANCELED
+	if cancellation_success:
+		_asset_pack_to_request_map.erase(pack_name)
+	
+	return cancellation_success
 
 # -----------------------------------------------------------------------------
 # Deletes the specified asset pack from the internal storage of the app.

--- a/api/src/play_asset_pack_manager.gd
+++ b/api/src/play_asset_pack_manager.gd
@@ -306,6 +306,8 @@ func cancel_asset_pack_request(pack_name : String) -> bool:
 	var updated_asset_pack_status = updated_asset_pack_state.get_status()
 	
 	var cancellation_success = updated_asset_pack_status == AssetPackStatus.CANCELED
+	# Since no global state_updated signal will be emitted in this case, we need to manual erase
+	# this pack if it is canceled.
 	if cancellation_success:
 		_asset_pack_to_request_map.erase(pack_name)
 	

--- a/api/src/play_asset_pack_manager.gd
+++ b/api/src/play_asset_pack_manager.gd
@@ -305,7 +305,7 @@ func cancel_asset_pack_request(pack_name : String) -> bool:
 	var updated_asset_pack_state : PlayAssetPackState = updated_asset_pack_states.get_pack_states()[pack_name]
 	var updated_asset_pack_status = updated_asset_pack_state.get_status()
 	
-	var cancellation_success = AssetPackStatus.CANCELED == AssetPackStatus.CANCELED
+	var cancellation_success = updated_asset_pack_status == AssetPackStatus.CANCELED
 	if cancellation_success:
 		_asset_pack_to_request_map.erase(pack_name)
 	

--- a/api/test/test_play_asset_pack_manager.gd
+++ b/api/test/test_play_asset_pack_manager.gd
@@ -637,20 +637,15 @@ func test_fetch_asset_pack_cancel():
 	assert_false(request_object.get_is_completed())
 	assert_asset_pack_state_eq_dict(request_object.get_state(), updated_state3)	
 	
-	test_object.cancel_asset_pack_request(test_pack_name)
-	var expected_state4 = create_mock_asset_pack_state_with_status_and_progress_dict(test_pack_name, \
-		PlayAssetPackManager.AssetPackStatus.CANCELED, 2048, 4096)
-	yield(yield_to(test_object, "state_updated", 1), YIELD)
+	var cancel_success = test_object.cancel_asset_pack_request(test_pack_name)
 	
-	assert_signal_emitted(test_object, "state_updated")
-	assert_true(request_object.get_is_completed())
-	assert_asset_pack_state_eq_dict(request_object.get_state(), expected_state4)
+	assert_eq(cancel_success, true)
 	
 	# assert signal_captor is as expected
 	var result_params_store = signal_captor.received_params_store
 	var expected_state_list = [test_asset_pack_state, updated_state1, updated_state2, \
-		updated_state3, expected_state4]
-	var expected_num_updates = 5
+		updated_state3]
+	var expected_num_updates = 4
 	var expected_signal_arg_count = 2
 	
 	assert_eq(result_params_store.size(), expected_num_updates)

--- a/api/test/test_play_asset_pack_manager.gd
+++ b/api/test/test_play_asset_pack_manager.gd
@@ -638,8 +638,7 @@ func test_fetch_asset_pack_cancel():
 	assert_asset_pack_state_eq_dict(request_object.get_state(), updated_state3)	
 	
 	var cancel_success = test_object.cancel_asset_pack_request(test_pack_name)
-	
-	assert_eq(cancel_success, true)
+	assert_true(cancel_success)
 	
 	# assert signal_captor is as expected
 	var result_params_store = signal_captor.received_params_store


### PR DESCRIPTION
Fixed a bug where the entries in _asset_pack_to_request_map are not erased in time.
This bug prevents a failed/canceled/removed asset pack to be refetched, since we are unable to create new request objects from calling ```fetch_asset_pack()```.
Also updated the test case ```test_fetch_asset_pack_cancel()``` since in real world scenarios, calling ```cancel()``` on an asset pack won't result in a global state updated signal.