### PR TITLE
Added pack_location field for PlayAssetPackFetchRequest

### DIFF
--- a/api/src/model/request/play_asset_pack_fetch_request.gd
+++ b/api/src/model/request/play_asset_pack_fetch_request.gd
@@ -30,7 +30,7 @@ extends PlayAssetDeliveryRequest
 # upon request reached terminal state {COMPLETED, CANCELED, FAILED}
 # 	pack_name: String, name of the requested asset pack
 # 	result : PlayAssetPackState object
-#	location : PlayAssetPackLocation if the request is in COMPLETED state, otherwise null
+#	pack_location : PlayAssetPackLocation if the request is in COMPLETED state, otherwise null
 #	exception: PlayAssetPackException object if Plugin encountered an exception
 # while handling this request
 # -----------------------------------------------------------------------------

--- a/api/src/model/request/play_asset_pack_fetch_request.gd
+++ b/api/src/model/request/play_asset_pack_fetch_request.gd
@@ -99,7 +99,7 @@ func _on_fetch_error(error: Dictionary):
 func _on_state_updated(result: Dictionary, location : PlayAssetPackLocation = null):
 	_state = PlayAssetPackState.new(result)
 	if _state.get_status() in PlayAssetPackManager._PACK_TERMINAL_STATES:
+		_location = location
 		# reached a terminal state, emit request_completed signal
-		emit_signal("request_completed", _pack_name, _state, null)
-	_location = location
+		emit_signal("request_completed", _pack_name, _state, _location, null)
 	

--- a/api/src/play_asset_pack_manager.gd
+++ b/api/src/play_asset_pack_manager.gd
@@ -148,11 +148,11 @@ func _route_asset_pack_state_updated(result : Dictionary):
 	
 	if _asset_pack_to_request_map.has(pack_name):
 		var request = _asset_pack_to_request_map[pack_name]
-		request.call_deferred("_on_state_updated", result)
+		var pack_location : PlayAssetPackLocation = null
+		if updated_status == AssetPackStatus.COMPLETED:
+			pack_location = get_pack_location(pack_name)
+		request.call_deferred("_on_state_updated", result, pack_location)
 	
-	if updated_status == AssetPackStatus.COMPLETED:
-		var pack_location : PlayAssetPackLocation = get_pack_location(pack_name)
-		call_deferred("emit_signal", "state_updated", pack_name, updated_state, pack_location)	
 	call_deferred("emit_signal", "state_updated", pack_name, updated_state)	
 	
 	_play_asset_pack_manager_mutex.unlock()

--- a/api/src/play_asset_pack_manager.gd
+++ b/api/src/play_asset_pack_manager.gd
@@ -150,6 +150,9 @@ func _route_asset_pack_state_updated(result : Dictionary):
 		var request = _asset_pack_to_request_map[pack_name]
 		request.call_deferred("_on_state_updated", result)
 	
+	if updated_status == AssetPackStatus.COMPLETED:
+		var pack_location : PlayAssetPackLocation = get_pack_location(pack_name)
+		call_deferred("emit_signal", "state_updated", pack_name, updated_state, pack_location)	
 	call_deferred("emit_signal", "state_updated", pack_name, updated_state)	
 	
 	_play_asset_pack_manager_mutex.unlock()

--- a/api/test/test_helper/base_test_class.gd
+++ b/api/test/test_helper/base_test_class.gd
@@ -98,6 +98,13 @@ func create_mock_asset_pack_states_dict() -> Dictionary:
 	
 	return test_dict
 
+func create_mock_asset_pack_location_dict() -> Dictionary:
+	return {
+		PlayAssetPackLocation._ASSETS_PATH_KEY: "/assetsPath/", 
+		PlayAssetPackLocation._PACK_STORAGE_METHOD_KEY: PlayAssetPackManager.AssetPackStorageMethod.STORAGE_FILES, 
+		PlayAssetLocation._PATH_KEY: "/path/"
+	}
+
 func create_mock_asset_locations_dict() -> Dictionary:
 	var pack_location_1_dict = {
 		PlayAssetPackLocation._ASSETS_PATH_KEY: "/assetsPath/", 

--- a/api/test/test_play_asset_pack_manager.gd
+++ b/api/test/test_play_asset_pack_manager.gd
@@ -60,11 +60,7 @@ func test_get_asset_location_not_exist():
 
 func test_get_asset_pack_location_valid():
 	var test_pack = "testPack"
-	var return_dict = {
-		PlayAssetPackLocation._ASSETS_PATH_KEY: "/assetsPath/", 
-		PlayAssetPackLocation._PACK_STORAGE_METHOD_KEY: PlayAssetPackManager.AssetPackStorageMethod.STORAGE_FILES, 
-		PlayAssetLocation._PATH_KEY: "/path/"
-	}
+	var return_dict = create_mock_asset_pack_location_dict()
 	
 	var mock_plugin = FakeAndroidPlugin.new()
 	mock_plugin.add_asset_pack_location(test_pack, return_dict)
@@ -76,11 +72,7 @@ func test_get_asset_pack_location_valid():
 
 func test_get_asset_pack_location_not_exist():
 	var test_pack = "testPack"
-	var return_dict = {
-		PlayAssetPackLocation._ASSETS_PATH_KEY: "/assetsPath/", 
-		PlayAssetPackLocation._PACK_STORAGE_METHOD_KEY: PlayAssetPackManager.AssetPackStorageMethod.STORAGE_FILES, 
-		PlayAssetLocation._PATH_KEY: "/path/"
-	}
+	var return_dict = create_mock_asset_pack_location_dict()
 	
 	var mock_plugin = FakeAndroidPlugin.new()
 	mock_plugin.add_asset_pack_location(test_pack, return_dict)
@@ -424,6 +416,10 @@ func test_fetch_asset_pack_success():
 		test_asset_pack_states, {})
 	mock_plugin.set_fetch_info(signal_info)
 	
+	# set return value for get_pack_location
+	var return_pack_location_dict = create_mock_asset_pack_location_dict()
+	mock_plugin.add_asset_pack_location(test_pack_name, return_pack_location_dict)
+	
 	var test_object = create_play_asset_pack_manager(mock_plugin)
 	
 	var request_object = test_object.fetch_asset_pack(test_pack_name)
@@ -489,6 +485,7 @@ func test_fetch_asset_pack_success():
 	assert_signal_emitted(test_object, "state_updated")
 	assert_true(request_object.get_is_completed())
 	assert_asset_pack_state_eq_dict(request_object.get_state(), updated_state4)	
+	assert_asset_pack_location_eq_dict(request_object.get_location(), create_mock_asset_pack_location_dict())	
 	
 	# assert signal_captor is as expected
 	var result_params_store = signal_captor.received_params_store
@@ -496,6 +493,7 @@ func test_fetch_asset_pack_success():
 		updated_state3, updated_state4]
 	var expected_num_updates = 5
 	var expected_signal_arg_count = 2
+	
 	assert_eq(result_params_store.size(), expected_num_updates)
 	# assert all entries in result_params_store
 	for i in range(expected_num_updates):
@@ -509,13 +507,14 @@ func test_fetch_asset_pack_success():
 	assert_true(not request_object_reference.get_ref())
 
 func assert_fetch_signal_is_completed(pack_name : String, \
-	result : PlayAssetPackState, exception : PlayAssetPackException):
+	result : PlayAssetPackState, pack_location : PlayAssetPackLocation, exception : PlayAssetPackException):
 	# assert using callback, simulating the workflow of connecting callback to signal
 	var expected_pack_name = "testPack"
 	var expected_pack_state_dict = create_mock_asset_pack_state_with_status_and_progress_dict(\
 		expected_pack_name, PlayAssetPackManager.AssetPackStatus.COMPLETED, 4096, 4096)
 	assert_eq(pack_name, expected_pack_name)
 	assert_asset_pack_state_eq_dict(result, expected_pack_state_dict)
+	assert_asset_pack_location_eq_dict(pack_location, create_mock_asset_pack_location_dict())
 	assert_eq(exception, null)
 
 func test_fetch_asset_pack_error():

--- a/api/test/test_play_asset_pack_manager.gd
+++ b/api/test/test_play_asset_pack_manager.gd
@@ -493,7 +493,6 @@ func test_fetch_asset_pack_success():
 		updated_state3, updated_state4]
 	var expected_num_updates = 5
 	var expected_signal_arg_count = 2
-	
 	assert_eq(result_params_store.size(), expected_num_updates)
 	# assert all entries in result_params_store
 	for i in range(expected_num_updates):
@@ -506,8 +505,8 @@ func test_fetch_asset_pack_success():
 	# assert reference is freed
 	assert_true(not request_object_reference.get_ref())
 
-func assert_fetch_signal_is_completed(pack_name : String, \
-	result : PlayAssetPackState, pack_location : PlayAssetPackLocation, exception : PlayAssetPackException):
+func assert_fetch_signal_is_completed(pack_name : String, result : PlayAssetPackState, \
+	pack_location : PlayAssetPackLocation, exception : PlayAssetPackException):
 	# assert using callback, simulating the workflow of connecting callback to signal
 	var expected_pack_name = "testPack"
 	var expected_pack_state_dict = create_mock_asset_pack_state_with_status_and_progress_dict(\


### PR DESCRIPTION
Added a ```get_location()``` method and updated the signal to ```signal request_completed(pack_name, result, pack_location, exception)``` for PlayAssetPackFetchRequest.
Included updated test cases.